### PR TITLE
Issue #2: Remove trailing zero option and old Drupal references.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-GLOBAL REDIRECT
+Global Redirect
 ===============
 
 GlobalRedirect is a simple module which redirects visitors from one page to another.
@@ -12,10 +12,10 @@ Redirections:
 - Checks if the Clean URLs feature is enabled and then checks the current URL is being accessed using the clean method rather than the 'unclean' method.
 - Checks access to the URL. If the user does not have access to the path, then no redirects are done. This helps avoid exposing private aliased node's.
 - Make sure the case of the URL being accessed is the same as the one set by the author/administrator. For example, if you set the alias "articles/cake-making" to node/123, then the user can access the alias with any combination of case.
-- Most of the above options are configurable in the settings page. In Backdrop 5 you can access this after enabling the globalredirect_admin module.
+- Most of the above options are configurable in the settings page.
 
 Current Maintainers
-------------------- 
+-------------------
 
 - docwilmot (https://github.com/docwilmot)
 - Nate Lampton (https://github.com/quicksketch)

--- a/globalredirect.admin.inc
+++ b/globalredirect.admin.inc
@@ -28,18 +28,6 @@ function globalredirect_settings() {
     '#default_value' => $settings['nonclean_to_clean'],
   );
 
-  $form['settings']['trailing_zero'] = array(
-    '#type' => 'radios',
-    '#title' => t('Remove Trailing Zero Argument'),
-    '#description' => t('If enabled, any instance of "/0" will be trimmed from the right of the URL. This stops duplicate pages such as "taxonomy/term/1" and "taxonomy/term/1/0" where 0 is the default depth. There is an option of limiting this feature to taxonomy term pages ONLY or allowing it to effect any page. <strong>By default this feature is disabled to avoid any unexpected behavior. Also of note, the trailing /0 "depth modifier" was removed from Backdrop 7.</strong>'),
-    '#options' => array(
-      0 => t('Disabled'),
-      1 => t('Enabled for all pages'),
-      2 => t('Enabled for taxonomy term pages only'),
-    ),
-    '#default_value' => $settings['trailing_zero'],
-  );
-
   $form['settings']['menu_check'] = array(
     '#type' => 'checkbox',
     '#title' => t('Menu Access Checking'),

--- a/globalredirect.install
+++ b/globalredirect.install
@@ -22,6 +22,13 @@ function globalredirect_update_1000() {
   update_variable_del('globalredirect_settings');
 }
 
+/**
+ * Remove the unused "trailing_zero" redirect setting.
+ */
+function globalredirect_update_1001() {
+  config_clear('globalredirect.settings', 'globalredirect_settings.trailing_zero');
+}
+
 // This is an ugly work-around because the Drupal 7 version of Global Redirect
 // still contains Drupal 6 update hooks. Backdrop will consider these newer than
 // any updates named globalredirect_update_1000() or higher. As such, we need
@@ -39,6 +46,7 @@ if (function_exists('state_get') &&
 
     // Manually execute remaining updates.
     globalredirect_update_1000();
+    globalredirect_update_1001();
   }
 
   /**
@@ -48,6 +56,6 @@ if (function_exists('state_get') &&
    * number is updated after update.php has executed update 6999.
    */
   function _globalredirect_update_6999() {
-    db_query("UPDATE {system} SET schema_version = 1000 WHERE name = 'globalredirect'");
+    db_query("UPDATE {system} SET schema_version = 1001 WHERE name = 'globalredirect'");
   }
 }

--- a/globalredirect.module
+++ b/globalredirect.module
@@ -105,26 +105,8 @@ function globalredirect_init() {
     return;
   }
 
-
   // Get the current page - it's already "deslashed"
   $current_path = current_path();
-
-
-  // Optional stripping of "/0". Disabled by default.
-  switch ($settings['trailing_zero']) {
-    case 2 :
-      // If 'taxonomy/term/*' only. If not, break out.
-      if (backdrop_substr($current_path, 0, 14) != 'taxonomy/term/') {
-        break;
-      }
-      // If it is, fall through to general trailing zero method
-    case 1 :
-      // If last 2 characters of URL are /0 then trim them off
-      if (backdrop_substr($current_path, -2) == '/0') {
-        $current_path = backdrop_substr($current_path, 0, -2);
-      }
-  }
-
 
   // If the feature is enabled, check and redirect taxonomy/term/* requests to their proper handler defined by hook_term_path().
   if ($settings['term_path_handler'] && module_exists('taxonomy') && preg_match('/taxonomy\/term\/([0-9]+)$/', $current_path, $matches)) {
@@ -364,7 +346,6 @@ function _globalredirect_get_settings($default_only = FALSE) {
   $defaults = array(
     'deslash' => 1,
     'nonclean_to_clean' => 1,
-    'trailing_zero' => 0,
     'menu_check' => 0,
     'case_sensitive_urls' => 1,
     'language_redirect' => 0,

--- a/tests/globalredirect.test
+++ b/tests/globalredirect.test
@@ -191,30 +191,6 @@ class GlobalRedirectTestCase extends BackdropWebTestCase {
         'expected-path' => $settings['term_path_handler'] ? 'forum/' . $this->gr_forum_term->tid : 'taxonomy/term/' . $this->gr_forum_term->tid,
       ),
 
-
-      // Trailing Zero Check --- This may or may not redirect, depending on the state of trailing_zero, as we're requesting an aliased path with a trailing zero source
-      // If 1, we trim ALL trailing /0... If 0 (disabled) or 2 (taxonomy term only), then a 200 response should be issued.
-      array(
-        'request' => 'node/1/0',
-        'return-code' => $settings['trailing_zero'] == 1 ? 301 : 200,
-        'expected-path' => $settings['trailing_zero'] == 1 ? 'test-node' : 'node/1/0',
-      ),
-
-      // Trailing Zero Check --- This may or may not redirect, depending on the state of trailing_zero, as we're requesting an aliased path with a trailing zero source
-      // If not disabled, then we should trim from taxonomy/term/1/0
-      array(
-        'request' => 'taxonomy/term/' . $this->gr_term->tid . '/0',
-        'return-code' => $settings['trailing_zero'] > 0 ? 301 : 200,
-        'expected-path' => $settings['trailing_zero'] > 0 ? 'test-term' : 'taxonomy/term/' .  $this->gr_term->tid . '/0',
-      ),
-
-      // Regression test for http://backdrop.org/node/867654 - term 10 does not exist
-      array(
-        'request' => 'taxonomy/term/10/0',
-        'return-code' => $settings['trailing_zero'] > 0 ? 301 : 404, // Term 10 does not exist in testing.
-        'expected-path' => $settings['trailing_zero'] > 0 ? 'taxonomy/term/10' : 'taxonomy/term/10/0',
-      ),
-
       // Regression test for http://backdrop.org/node/867654 - term 10 does not exist
       array(
         'request' => 'admin',
@@ -345,7 +321,6 @@ class GlobalRedirectTestCaseDefault extends GlobalRedirectTestCase {
       'case_sensitive_urls' => 1,
       'term_path_handler' => 1,
       'frontpage_redirect' => 1,
-      'trailing_zero' => 0,
       'ignore_admin_path' => 1,
     ));
     $this->_globalredirect_batch_test();
@@ -370,7 +345,6 @@ class GlobalRedirectTestCaseConfigAlpha extends GlobalRedirectTestCase {
       'case_sensitive_urls' => 0,
       'term_path_handler' => 0,
       'frontpage_redirect' => 0,
-      'trailing_zero' => 1,
       'ignore_admin_path' => 0,
     ));
 
@@ -397,7 +371,6 @@ class GlobalRedirectTestCaseConfigBeta extends GlobalRedirectTestCase {
       'case_sensitive_urls' => 0,
       'term_path_handler' => 0,
       'frontpage_redirect' => 0,
-      'trailing_zero' => 0,
     ));
 
     $this->_globalredirect_batch_test();


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/globalredirect/issues/2.